### PR TITLE
Remove unnecessary mod operation.

### DIFF
--- a/siec.go
+++ b/siec.go
@@ -38,7 +38,6 @@ func (curve *SIEC255Params) Params() *SIEC255Params {
 func (curve *SIEC255Params) IsOnCurve(x, y *big.Int) bool {
 	// y² = x³ + 19
 	LHS := new(big.Int).Exp(y, two, curve.P)
-	LHS.Mod(LHS, curve.P)
 	RHS := new(big.Int).Exp(x, three, curve.P)
 	RHS.Add(RHS, nineteen)
 	RHS.Mod(RHS, curve.P)


### PR DESCRIPTION
Exp already returns a big.Int mod p.